### PR TITLE
Allow relative PATH entries on Go 1.19+

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        go: [1.13, 1.14, 1.15]
+        go: [1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19, 1.20]
 
     runs-on: ${{matrix.os}}
     steps:

--- a/lookpath.go
+++ b/lookpath.go
@@ -1,9 +1,17 @@
-// +build !windows
+//go:build !windows && go1.19
+// +build !windows,go1.19
 
 package safeexec
 
-import "os/exec"
+import (
+	"errors"
+	"os/exec"
+)
 
 func LookPath(file string) (string, error) {
-	return exec.LookPath(file)
+	path, err := exec.LookPath(file)
+	if errors.Is(err, exec.ErrDot) {
+		return path, nil
+	}
+	return path, err
 }

--- a/lookpath_1.18.go
+++ b/lookpath_1.18.go
@@ -1,0 +1,10 @@
+//go:build !windows && !go1.19
+// +build !windows,!go1.19
+
+package safeexec
+
+import "os/exec"
+
+func LookPath(file string) (string, error) {
+	return exec.LookPath(file)
+}


### PR DESCRIPTION
This ignores the new type of error introduced in Go 1.19: `exec.IsDot`